### PR TITLE
feat: Only allow access to files through cleanup block

### DIFF
--- a/forced_file_from_url.gemspec
+++ b/forced_file_from_url.gemspec
@@ -6,11 +6,11 @@ require 'forced_file_from_url/version'
 Gem::Specification.new do |spec|
   spec.name          = "forced_file_from_url"
   spec.version       = ForcedFileFromUrl::VERSION
-  spec.authors       = ["Diego Salazar"]
-  spec.email         = ["diego@greyrobot.com"]
+  spec.authors       = ["Sampson Crowley"]
+  spec.email         = ["sampson.crowley@kipuhealth.com"]
   spec.summary       = %q{Tiny hack to convert StringIO objects into Tempfile when using OpenURI to open files less than 10kb.}
   spec.description   = %q{Tiny hack to convert StringIO objects into Tempfile when using OpenURI to open files less than 10kb.}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/kipuhealth/forced_file_from_url.git"
   spec.license       = "MIT"
 
   if spec.respond_to?(:metadata)

--- a/lib/forced_file_from_url.rb
+++ b/lib/forced_file_from_url.rb
@@ -6,26 +6,53 @@ module ForcedFileFromUrl
 
   # Using open-uri to open files that are less than 10kb will return a StringIO object.
   # This causes a problem when trying to call #path on the object which is not available
-  # in StringIO objects but rather File and Tempfile objects. This method writes the data 
+  # in StringIO objects but rather File and Tempfile objects. This method writes the data
   # to a Tempfile when the data is a StringIO.
   def forced_file_from_url(url)
+    file = nil
+
     data = open URI.parse(url)
-    return data if data.is_a? Tempfile
+    if data.is_a? Tempfile
+      file = data
+    else
+      extname = File.extname url
+      basename = File.basename url, extname
 
-    extname = File.extname url
-    basename = File.basename url, extname
+      file = Tempfile.new [basename, extname]
+      file.binmode
+      file.write data.read
+      file.rewind
+    end
 
-    file = Tempfile.new [basename, extname]
-    file.binmode
-    file.write data.read
-    file.rewind
-    file
+    if block_given?
+      begin
+        yield file
+      ensure
+        file.close
+        file.unlink
+      end
+    else
+      file
+    end
   end
 
   # Takes a paperclip attachment, downloads the file to tmp, and returns a file handle
   def file_from_paperclip_attachment(attachment, style: :original)
-    url = Rails.root.join("/tmp/#{attachment.instance_read :file_name}").to_s
-    attachment.copy_to_local_file style, url
-    File.open url, ?r
+    filename = attachment.instance_read :file_name
+    extname = File.extname filename
+    basename = File.basename filename, extname
+    file = Tempfile.new([basename, extname])
+    attachment.copy_to_local_file style, file.path
+    file.rewind
+    if block_given?
+      begin
+        yield file
+      ensure
+        file.close
+        file.unlink
+      end
+    else
+      file
+    end
   end
 end

--- a/lib/forced_file_from_url.rb
+++ b/lib/forced_file_from_url.rb
@@ -24,26 +24,46 @@ module ForcedFileFromUrl
       file.rewind
     end
 
-    if block_given?
-      begin
-        yield file
-      ensure
-        file.close
-        file.unlink
-      end
-    else
-      file
-    end
+    _handle_ff_file(file, &block)
   end
 
   # Takes a paperclip attachment, downloads the file to tmp, and returns a file handle
-  def file_from_paperclip_attachment(attachment, style: :original)
+  def file_from_paperclip_attachment(attachment, style: :original, &block)
     filename = attachment.instance_read :file_name
     extname = File.extname filename
     basename = File.basename filename, extname
     file = Tempfile.new([basename, extname])
     attachment.copy_to_local_file style, file.path
     file.rewind
+
+    _handle_ff_file(file, &block)
+  end
+
+  def with_file_from_url_cleanup
+    yield if _within_ff_cleanup_block?
+    open_files = _open_ff_files
+    begin
+      @__block_open = true
+      yield
+    ensure
+      @open_files = []
+      @__block_open = false
+      open_files.each {|file|
+        file.close
+        file.unlink
+      }
+    end
+  end
+
+  def _open_ff_files
+    @open_files ||= []
+  end
+
+  def _within_ff_cleanup_block?
+    @__block_open
+  end
+
+  def _handle_ff_file(file, &block)
     if block_given?
       begin
         yield file
@@ -51,8 +71,14 @@ module ForcedFileFromUrl
         file.close
         file.unlink
       end
-    else
+    elsif _within_ff_cleanup_block?
+      # even if cleanup is forgotten it can be done on the next batch :evilsmile:
+      _open_ff_files << file
       file
+    else
+      file.close
+      file.unlink
+      raise ArgumentError, "unsafe file cleanup practice detected!"
     end
   end
 end

--- a/lib/forced_file_from_url/version.rb
+++ b/lib/forced_file_from_url/version.rb
@@ -1,3 +1,3 @@
 module ForcedFileFromUrl
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/lib/forced_file_from_url/version.rb
+++ b/lib/forced_file_from_url/version.rb
@@ -1,3 +1,3 @@
 module ForcedFileFromUrl
-  VERSION = "0.0.2"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Direct file descriptor access is dangerous. especially leaving thousands upon thousands of files open in a `tmp` directory that does not get cleaned up by system processes